### PR TITLE
Add support for raw body in send_request

### DIFF
--- a/esclient.py
+++ b/esclient.py
@@ -83,7 +83,7 @@ class ESClient:
         if key in results:
             return results[key] == value
         
-    def send_request(self, method, path, body=None, query_string_args={}):
+    def send_request(self, method, path, body=None, query_string_args={},encode_json=True):
         """Make a raw HTTP request to ElasticSearch.
 
         You may use this method to manually do whatever is not (yet) supported
@@ -107,7 +107,10 @@ class ESClient:
         url = self.es_url + path
 
         if body:
-            kwargs['data'] = json.dumps(body)
+            if encode_json:
+                kwargs['data'] = json.dumps(body)
+            else:
+                kwargs['data'] = body
 
         if not hasattr(requests, method.lower()):
             raise ESClientException("No such HTTP Method '%s'!" %


### PR DESCRIPTION
Hi, I've added an encode_json argument to send_request, this allows the use of send_request for batch, multisearch and multiget operations which require raw binary data instead of json encoded.

Hope you can add this to your master branch.

Thanks for sharing this great work with everyone!.

Matias.
