### PR TITLE
Add support of Travis CI continuous integration service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
    - "pypy"
 
 install:
-   - if [[ $TRAVIS_PYTHON_VERSION == '2.5' ]]; then pip install chardet2 
+   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install chardet2; fi 
    - pip install requests simplejson
    - python setup.py install
 


### PR DESCRIPTION
Continuous integration is so fun with Travis CI :-)

[Builds and tests on Python 2.6, 2.7, pypy, 3.2.](https://travis-ci.org/#!/2xyo/ESClient)
1.  Accept (or not..) this pull request
2.  Go to https://travis-ci.org/
3.  Sign in with Github
4.  Activate your ESClient project
