### PR TITLE
Supported `_parent` and `_routing` in `fields` field for elasticsearch v1.4.1

### DIFF
--- a/bin/esimport
+++ b/bin/esimport
@@ -77,12 +77,12 @@ for doc in f:
         doctype = doc["_type"]
 
     try:    
-        parent = doc["_parent"]
+        parent = doc["fields"]["_parent"]
     except KeyError:
         parent = None
 
     try:
-        routing = doc["_routing"]
+        routing = doc["fields"]["_routing"]
     except KeyError:
         routing = None
 


### PR DESCRIPTION
Fix `_parent` and `_routing` field in `fields` field, my version is elasticsearch v1.4.1.

Exported file example, `_parent` and `_routing` in nested `fields` field.
```json
{"_type": "message", "_source": {}, "_index": "1416766435", "fields": {"_parent": "", "_routing": ""}, "_id": "2092199926148"}
```

```bash
$ curl -X GET http://localhost:9200
{
  "status" : 200,
  "name" : "Stephen Strange",
  "cluster_name" : "elasticsearch",
  "version" : {
    "number" : "1.4.1",
    "build_hash" : "89d3241d670db65f994242c8e8383b169779e2d4",
    "build_timestamp" : "2014-11-26T15:49:29Z",
    "build_snapshot" : false,
    "lucene_version" : "4.10.2"
  },
  "tagline" : "You Know, for Search"
}
```

I'm afraid my expressions may be rude or hard to read, because I'm not so good at English.